### PR TITLE
Update user-service port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   user-service:
     build: ./user-service
     ports:
-      - "8081:8080"
+      - "8082:8080"
     container_name: user-service
 
   content-service:

--- a/frontend/env.local.yml
+++ b/frontend/env.local.yml
@@ -1,5 +1,5 @@
 # Frontend .env.local
 NEXT_PUBLIC_API_URL=http://localhost:8080
-NEXT_PUBLIC_AUTH_URL=http://localhost:8081
+NEXT_PUBLIC_AUTH_URL=http://localhost:8082
 NEXT_PUBLIC_CONTENT_URL=http://localhost:8082
 NEXT_PUBLIC_MEDIA_URL=http://localhost:8083


### PR DESCRIPTION
## Summary
- expose `user-service` on port 8082
- update frontend environment config to use the new auth port

## Testing
- `python3 - <<'PY'
import yaml; yaml.safe_load(open('docker-compose.yml'))
print("compose valid")
PY`
- `./content-service/gradlew test --no-daemon`
- `./media-service/gradlew test --no-daemon` *(fails: MediaProcessingTests)*
- `./api-gateway/gradlew test --no-daemon` *(fails: Java toolchain not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843905cd4748326b20416b8e03e5acc