### PR TITLE
Add Auth0 profile fetch and basic media upload endpoint

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -18,7 +18,10 @@ useEffect(() => {
         const token = await getAccessTokenSilently();
         localStorage.setItem('auth_token', token);
         try {
-          await userService.getCurrentUserProfile();
+          const { data } = await userService.getCurrentUserProfile();
+          if (data && data.id) {
+            localStorage.setItem('user_id', data.id);
+          }
         } catch (profileErr) {
           console.error('❌ Error fetching profile:', profileErr.message);
         }

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { X, UploadIcon, Tag } from "lucide-react"
 import { motion } from "framer-motion"
+import { contentService, mediaService } from "../services/api"
 
 export default function Upload() {
   const navigate = useNavigate()
@@ -71,7 +72,7 @@ export default function Upload() {
     setTags(tags.filter((tag) => tag !== tagToRemove))
   }
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault()
 
     if (!file) {
@@ -84,22 +85,30 @@ export default function Upload() {
       return
     }
 
-    // Simulate upload process
     setLoading(true)
 
-    setTimeout(() => {
-      // In a real app, this would be an API call to upload the file and metadata
-      console.log({
-        file,
+    try {
+      const uploadRes = await mediaService.uploadMedia(file)
+      const mediaKey = uploadRes.data.key
+
+      const userId = Number(localStorage.getItem('user_id'))
+      const contentData = {
+        userId,
+        type: 'image',
         title,
         description,
         tags,
-      })
+        mediaUrls: [mediaKey],
+      }
 
+      await contentService.createContent(contentData)
+      navigate('/explore')
+    } catch (err) {
+      console.error('Upload failed', err)
+      alert('Upload failed')
+    } finally {
       setLoading(false)
-      // Redirect to a success page or the pin detail page
-      navigate("/explore")
-    }, 2000)
+    }
   }
 
   return (

--- a/media-service/src/main/java/com/inspira/mediaprocessing/controller/MediaUploadController.java
+++ b/media-service/src/main/java/com/inspira/mediaprocessing/controller/MediaUploadController.java
@@ -1,0 +1,31 @@
+package com.inspira.mediaprocessing.controller;
+
+import com.inspira.mediaprocessing.dto.MediaUploadResponse;
+import com.inspira.mediaprocessing.service.S3Client;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/media")
+public class MediaUploadController {
+    private final S3Client s3Client;
+
+    public MediaUploadController(S3Client s3Client) {
+        this.s3Client = s3Client;
+    }
+
+    @PostMapping("/upload")
+    public ResponseEntity<MediaUploadResponse> upload(@RequestParam("file") MultipartFile file) throws IOException {
+        String key = UUID.randomUUID() + "-" + file.getOriginalFilename();
+        s3Client.upload(key, file.getBytes());
+        MediaUploadResponse resp = new MediaUploadResponse(key);
+        return ResponseEntity.ok(resp);
+    }
+}

--- a/media-service/src/main/java/com/inspira/mediaprocessing/dto/MediaUploadResponse.java
+++ b/media-service/src/main/java/com/inspira/mediaprocessing/dto/MediaUploadResponse.java
@@ -1,0 +1,19 @@
+package com.inspira.mediaprocessing.dto;
+
+public class MediaUploadResponse {
+    private String key;
+
+    public MediaUploadResponse() {}
+
+    public MediaUploadResponse(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+}


### PR DESCRIPTION
## Summary
- store logged in user id in `Navbar` after retrieving profile
- allow uploading content to backend from `Upload` page
- expose `/api/v1/media/upload` endpoint in media service

## Testing
- `../content-service/gradlew test --no-daemon` *(fails: Execution failed for task ':test')*

------
https://chatgpt.com/codex/tasks/task_e_6844b0c24e2c8326a6842bdcd1a9228f